### PR TITLE
Update default for use_parent arg to match docs

### DIFF
--- a/lib/absinthe/resolution/helpers.ex
+++ b/lib/absinthe/resolution/helpers.ex
@@ -270,7 +270,7 @@ defmodule Absinthe.Resolution.Helpers do
     end
 
     defp use_parent(loader, source, resource, parent, args, opts) do
-      with true <- Keyword.get(opts, :use_parent, false),
+      with true <- Keyword.get(opts, :use_parent, true),
            {:ok, val} <- is_map(parent) && Map.fetch(parent, resource) do
         Dataloader.put(loader, source, {resource, args}, parent, val)
       else


### PR DESCRIPTION
<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
The docs for the `dataloader/3` function say:
> `:use_parent` default: `true` This option affects whether or not ....

This is just changes the default value for the `:use_parent` option to actually be `true`.